### PR TITLE
Support several langs tags in meta info

### DIFF
--- a/njtai/src/njtai/models/ExtMangaObj.java
+++ b/njtai/src/njtai/models/ExtMangaObj.java
@@ -66,20 +66,21 @@ public class ExtMangaObj extends MangaObj implements Runnable {
 		} catch (Exception e) {
 			tags = "(error)";
 		}
-		lang = meta.indexOf("Languages:") == -1 ? null
-				: StringUtil.range(StringUtil.range(meta, "Languages:", "</div", false), "<span class=\"name\">",
-						"</span", false);
+		try {
+			if (meta.indexOf("Languages:") == -1)
+				lang = null;
+			else
+				lang = listLangs(StringUtil.splitRanges(StringUtil.range(meta, "Languages:", "</div", false),
+						"<span class=\"name\">", "</span", false));
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			lang = null;
+		}
 		parody = meta.indexOf("Parodies:") == -1 ? null
 				: StringUtil.range(StringUtil.range(meta, "Parodies:", "</div", false), "<span class=\"name\">",
 						"</span", false);
-		if (NJTAI.rus && lang != null) {
-			if (lang.equals("japanese"))
-				lang = "японский";
-			else if (lang.equals("english"))
-				lang = "английский";
-			else if (lang.equals("chinese"))
-				lang = "китайский";
-		}
+
 		System.gc();
 	}
 
@@ -231,5 +232,34 @@ public class ExtMangaObj extends MangaObj implements Runnable {
 			sb.append(list[i]);
 		}
 		return sb.toString();
+	}
+
+	public static String listLangs(String[] list) {
+		if (list == null)
+			return null;
+		if (list.length == 0)
+			return null;
+		StringBuffer sb = new StringBuffer();
+		sb.append(translateLang(list[0]));
+		for (int i = 1; i < list.length; i++) {
+			sb.append(", ");
+			String s = translateLang(list[i]);
+			sb.append(s);
+		}
+		return sb.toString();
+	}
+
+	private static String translateLang(String s) {
+		if (NJTAI.rus) {
+			if (s.equals("japanese"))
+				s = "японский";
+			else if (s.equals("english"))
+				s = "английский";
+			else if (s.equals("chinese"))
+				s = "китайский";
+			else if (s.equals("translated"))
+				s = "перевод";
+		}
+		return s;
 	}
 }


### PR DESCRIPTION
Некоторые тайтлы имеют два тэга языка, чаще всего это "перевод" и язык, на который перевели. До этого PR на странице показывалось бы лишь translated. Теперь показывается и сам язык.